### PR TITLE
Fix documentation for registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This library can be used untyped with vanilla JavaScript to generate registerabl
 import { ComputeModule } from "@palantir/compute-module";
 
 new ComputeModule()
-  .on("addOne", async (n) => n + 1)
-  .on("stringify", async (n) => "" + n)
+  .register("addOne", async (n) => n + 1)
+  .register("stringify", async (n) => "" + n)
   .default(() => ({ error: "Unsupported query name" }));
 ```
 
@@ -52,7 +52,7 @@ const myModule = new ComputeModule({
   },
 });
 
-myModule.on("addOne", async (n) => n + 1);
+myModule.register("addOne", async (n) => n + 1);
 ```
 
 ## Pipelines Mode

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This library can be used untyped with vanilla JavaScript to generate registerabl
 import { ComputeModule } from "@palantir/compute-module";
 
 new ComputeModule()
-  .register("addOne", async (n) => n + 1)
-  .register("stringify", async (n) => "" + n)
+  .register("addOne", async ({ value }) => ({ value: n + 1 }));
+  .register("stringify", async ({ n }) => "" + n)
   .default(() => ({ error: "Unsupported query name" }));
 ```
 
@@ -52,7 +52,7 @@ const myModule = new ComputeModule({
   },
 });
 
-myModule.register("addOne", async (n) => n + 1);
+myModule.register("addOne", async ({ value }) => ({ value: n + 1 }));
 ```
 
 ## Pipelines Mode

--- a/typescript-compute-module/src/api/ComputeModuleApi.ts
+++ b/typescript-compute-module/src/api/ComputeModuleApi.ts
@@ -40,7 +40,7 @@ export class ComputeModuleApi {
   public postResult = <ResponseType>(jobId: string, response: ResponseType) =>
     this.axiosInstance.post(
       this.connectionInformation.postResultUri + "/" + jobId,
-      response,
+      typeof response === "number" ? response.toString() : response,
       {
         headers: {
           "Content-Type": "application/octet-stream",


### PR DESCRIPTION
Documentation implied you should use the on keyword, rather than register. This will also ensure that type is string, not number.