### PR TITLE
Enable autoregistry in the example module

### DIFF
--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -3,7 +3,6 @@ import { Type } from "@sinclair/typebox";
 
 const computeModule = new ComputeModule({
   logger: console,
-  isAutoRegistered: false,
   definitions: {
     getEnv: {
       input: Type.Object({}),


### PR DESCRIPTION
This now works so we should enable by default (by removing the parameter)