### PR TITLE
Fix serialization for Function types

### DIFF
--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -7,7 +7,9 @@ const computeModule = new ComputeModule({
   definitions: {
     getEnv: {
       input: Type.Object({}),
-      output: Type.Object({}),
+      output: Type.Object({
+        SERVICE_HOST: Type.String(),
+      }),
     },
     wait: {
       input: Type.Object({
@@ -72,7 +74,9 @@ if (computeModule.environment.type === "pipelines") {
       });
     })
     .register("getEnv", async () => {
-      return process.env;
+      return {
+        SERVICE_HOST: process.env.SERVICE_HOST ?? "Not found",
+      };
     })
     .register("getCredential", async (v) => {
       return (

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -3,7 +3,6 @@ import { Type } from "@sinclair/typebox";
 
 const computeModule = new ComputeModule({
   logger: console,
-  isAutoRegistered: false,
   definitions: {
     getEnv: {
       input: Type.Object({}),

--- a/typescript-compute-module/src/api/ComputeModuleApi.ts
+++ b/typescript-compute-module/src/api/ComputeModuleApi.ts
@@ -40,7 +40,7 @@ export class ComputeModuleApi {
   public postResult = <ResponseType>(jobId: string, response: ResponseType) =>
     this.axiosInstance.post(
       this.connectionInformation.postResultUri + "/" + jobId,
-      typeof response === "number" ? response.toString() : response,
+      JSON.stringify(response),
       {
         headers: {
           "Content-Type": "application/octet-stream",


### PR DESCRIPTION
Function types require JSON stringification when sent as an octet-stream, otherwise they won't be callable in Foundry applications.

I also set the example to now autoRegister again since that feature is fixed.

Finally, I've skipped ECONNREFUSED errors on startup as we expect to hit a server that is missing.