### PR TITLE
Add streaming API to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ new ComputeModule()
 
 ### Streaming usage
 
-You can stream responses back from the compute module, rather than all at once. Type safety is not provided on the response here as the SDL cannot validate that the stream was of the correct type, we recommend that you only set your return value to String in these cases.
+You can stream responses back from the compute module, rather than all at once. Type safety is not provided on the response here as the SDK cannot validate that the stream was of the correct type, we recommend that you only set your return value to String in these cases.
 
 ```ts
 import { ComputeModule } from "@palantir/compute-module";

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Node.JS compatible implementation of the Palantir Compute Module specification.
 - [@palantir/compute-module](#palantircompute-module)
   - [Functions Mode](#functions-mode)
     - [Basic usage](#basic-usage)
+    - [Streaming usage](#streaming-usage)
     - [Schema registration](#schema-registration)
   - [Pipelines Mode](#pipelines-mode)
     - [Retrieving aliases](#retrieving-aliases)
@@ -31,6 +32,23 @@ new ComputeModule()
   .register("stringify", async ({ n }) => "" + n)
   .default(() => ({ error: "Unsupported query name" }));
 ```
+
+### Streaming usage
+
+You can stream responses back from the compute module, rather than all at once. Type safety is not provided on the response here as the SDL cannot validate that the stream was of the correct type, we recommend that you only set your return value to String in these cases.
+
+```ts
+import { ComputeModule } from "@palantir/compute-module";
+
+new ComputeModule()
+  .registerStreaming("hello", async ({ world }, writeable: Writeable) => {
+    writeable.write("Hello");
+    writeable.write(world);
+    writeable.end();
+  });
+  .default(() => ({ error: "Unsupported query name" }));
+```
+
 
 ### Schema registration
 

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -7,7 +7,9 @@ const computeModule = new ComputeModule({
   definitions: {
     getEnv: {
       input: Type.Object({}),
-      output: Type.Object({}),
+      output: Type.Object({
+        SERVICE_HOST: Type.String(),
+      }),
     },
     wait: {
       input: Type.Object({
@@ -72,7 +74,9 @@ if (computeModule.environment.type === "pipelines") {
       });
     })
     .register("getEnv", async () => {
-      return process.env;
+      return {
+        SERVICE_HOST: process.env.SERVICE_HOST ?? "Not found",
+      };
     })
     .register("getCredential", async (v) => {
       return (

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -3,7 +3,6 @@ import { Type } from "@sinclair/typebox";
 
 const computeModule = new ComputeModule({
   logger: console,
-  isAutoRegistered: false,
   definitions: {
     getEnv: {
       input: Type.Object({}),

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -38,6 +38,10 @@ const computeModule = new ComputeModule({
       input: Type.Object({}),
       output: Type.String(),
     },
+    streamable: {
+      input: Type.Object({}),
+      output: Type.String(),
+    }
   },
 });
 
@@ -85,5 +89,15 @@ if (computeModule.environment.type === "pipelines") {
     .register("openFile", async (v) => {
       const fileContents = require("fs").readFileSync(v.path, "utf-8");
       return fileContents;
+    }).registerStreaming("streamable", (input, writeable) => {
+      let count = 10;
+      let interval = setInterval(() => {
+        writeable.write("Hello, World!");
+        count--;
+        if (count === 0) {
+          clearInterval(interval);
+          writeable.end();
+        }
+      }, 1000);
     });
 }

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -1,8 +1,8 @@
 import { Logger, loggerToInstanceLogger } from "./logger";
 import {
-  QueryListener,
   QueryResponseMapping,
   QueryRunner,
+  QueryListener,
 } from "./QueryRunner";
 import { ComputeModuleApi, formatAxiosErrorResponse } from "./api/ComputeModuleApi";
 import { convertJsonSchemaToCustomSchema } from "./api/convertJsonSchematoFoundrySchema";
@@ -16,6 +16,7 @@ import {
 } from "./services/getFoundryServices";
 import * as fs from "fs";
 import { isAxiosError } from "axios";
+import { Writable } from "stream";
 
 export interface ComputeModuleOptions<M extends QueryResponseMapping = any> {
   /**
@@ -121,7 +122,24 @@ export class ComputeModule<M extends QueryResponseMapping> {
     queryName: T,
     listener: (data: Static<M[T]["input"]>) => Promise<Static<M[T]["output"]>>
   ) {
-    this.listeners[queryName] = listener;
+    this.listeners[queryName] = { type: "response", listener };
+    return this;
+  }
+
+  /**
+   * Adds a listener for a specific query, only one streaming listener can be added per query
+   * @param queryName Foundry query name to respond to
+   * @param listener Function to run when the query is received
+   * @returns
+   */
+  public registerStreaming<T extends keyof M>(
+    queryName: T,
+    listener: (
+      data: Static<M[T]["input"]>,
+      writable: Writable
+    ) => void
+  ) {
+    this.listeners[queryName] = { type: "streaming", listener };
     return this;
   }
 

--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -3,6 +3,7 @@ import { Logger } from "./logger";
 import { Static, TObject } from "@sinclair/typebox";
 import { ComputeModuleApi, formatAxiosErrorResponse } from "./api/ComputeModuleApi";
 import { SupportedTypeboxTypes } from "./api/convertJsonSchematoFoundrySchema";
+import { PassThrough, Writable } from "stream";
 
 export interface QueryResponseMapping {
   [queryType: string]: {
@@ -11,7 +12,20 @@ export interface QueryResponseMapping {
   };
 }
 
-export type QueryListener<M extends QueryResponseMapping> = <T extends keyof M>(
+export type QueryListener<M extends QueryResponseMapping> = {
+  type: "response";
+  listener: ResponseQueryListener<M>;
+} | {
+  type: "streaming";
+  listener: StreamingQueryListener<M>;
+};
+
+export type StreamingQueryListener<M extends QueryResponseMapping> = <T extends keyof M>(
+  message: Static<M[T]["input"]>,
+  responseStream: Writable
+) => void;
+
+export type ResponseQueryListener<M extends QueryResponseMapping> = <T extends keyof M>(
   message: Static<M[T]["input"]>
 ) => Promise<Static<M[T]["output"]>>;
 
@@ -44,10 +58,14 @@ export class QueryRunner<M extends QueryResponseMapping> {
           this.logger?.info(`Job received - ID: ${jobId} Query: ${queryType}`);
           const listener = this.listeners[queryType];
 
-          if (listener != null) {
-            listener(query).then((response) =>
+          if (listener?.type === "response") {
+            listener.listener(query).then((response) =>
               computeModuleApi.postResult(jobId, response)
             );
+          } else if (listener?.type === "streaming") {
+            const writable = new PassThrough();
+            listener.listener(query, writable);
+            computeModuleApi.postStreamingResult(jobId, writable);
           } else if (this.defaultListener != null) {
             this.defaultListener(query, queryType).then((response) =>
               computeModuleApi.postResult(

--- a/typescript-compute-module/src/api/ComputeModuleApi.ts
+++ b/typescript-compute-module/src/api/ComputeModuleApi.ts
@@ -40,7 +40,7 @@ export class ComputeModuleApi {
   public postResult = <ResponseType>(jobId: string, response: ResponseType) =>
     this.axiosInstance.post(
       this.connectionInformation.postResultUri + "/" + jobId,
-      typeof response === "number" ? response.toString() : response,
+      JSON.stringify(response),
       {
         headers: {
           "Content-Type": "application/octet-stream",

--- a/typescript-compute-module/src/api/ComputeModuleApi.ts
+++ b/typescript-compute-module/src/api/ComputeModuleApi.ts
@@ -1,6 +1,7 @@
 import https from "https";
 import { Schema } from "./schemaTypes";
 import axios, { AxiosError } from "axios";
+import { Writable } from "stream";
 
 export interface ConnectionInformation {
   getJobUri: string; // GET_JOB_URI
@@ -47,6 +48,19 @@ export class ComputeModuleApi {
         },
       }
     );
+
+  public postStreamingResult = (jobId: string, response: Writable) => {
+    this.axiosInstance.post(
+      this.connectionInformation.postResultUri + "/" + jobId,
+      response,
+      {
+        headers: {
+          "Content-Type": "application/octet-stream",
+        },
+      }
+    );
+  }
+ 
 
   public postSchema = (schemas: Schema[]) =>
     this.axiosInstance.post(this.connectionInformation.postSchemaUri, schemas, {


### PR DESCRIPTION
Allows the streaming of a result back to the runtime, rather than a standard synchronous post.