### PR TITLE
Fix the list type to match the IDataType schema

### DIFF
--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -4,6 +4,21 @@ import { Type } from "@sinclair/typebox";
 const computeModule = new ComputeModule({
   logger: console,
   definitions: {
+    chat: {
+      input: Type.Object({
+        messages: Type.Array(
+          Type.Object({
+            role: Type.String(),
+            content: Type.String(),
+          })
+        ),
+        temperature: Type.Number(),
+        max_tokens: Type.Number(),
+      }),
+      output: Type.Object({
+        messages: Type.Array(Type.String()),
+      }),
+    },
     getEnv: {
       input: Type.Object({}),
       output: Type.Object({
@@ -99,5 +114,10 @@ if (computeModule.environment.type === "pipelines") {
           writeable.end();
         }
       }, 1000);
+    })
+    .register("chat", async (v) => {
+      return {
+        messages: v.messages.map((m) => `${m.role}: ${m.content}`),
+      };
     });
 }

--- a/typescript-compute-module/src/api/convertJsonSchematoFoundrySchema.ts
+++ b/typescript-compute-module/src/api/convertJsonSchematoFoundrySchema.ts
@@ -57,7 +57,7 @@ function convertJsonType(jsonType: TSchema): Schema.DataType {
     return {
       type: "list",
       list: {
-        elementTypes: convertJsonType(jsonType.items),
+        elementsType: convertJsonType(jsonType.items),
       },
     };
   } else if (TypeGuard.IsBoolean(jsonType)) {

--- a/typescript-compute-module/src/api/schemaTypes.ts
+++ b/typescript-compute-module/src/api/schemaTypes.ts
@@ -47,7 +47,7 @@ export namespace Schema {
   export type ListType = {
     type: "list";
     list: {
-      elementTypes: DataType;
+      elementsType: DataType;
     };
   }
 

--- a/typescript-compute-module/src/api/tests/convertJsonSchemaToCustomSchema.test.ts
+++ b/typescript-compute-module/src/api/tests/convertJsonSchemaToCustomSchema.test.ts
@@ -10,8 +10,26 @@ const EXAMPLE_DEFINITION = {
   },
 };
 
+const CHAT_DEFINITION = {
+  chat: {
+    input: Type.Object({
+      messages: Type.Array(
+        Type.Object({
+          role: Type.String(),
+          content: Type.String(),
+        })
+      ),
+      temperature: Type.Number(),
+      max_tokens: Type.Number(),
+    }),
+    output: Type.Object({
+      messages: Type.Array(Type.String()),
+    }),
+  },
+};
+
 describe("Type tests", () => {
-  it("should have the same types", () => {
+  it("should have the same types as a simple definition", () => {
     const schema = convertJsonSchemaToCustomSchema(
       "isFirstName",
       EXAMPLE_DEFINITION.isFirstName.input,
@@ -28,7 +46,7 @@ describe("Type tests", () => {
             string: {},
           },
           constraints: [],
-        }
+        },
       ],
       output: {
         type: "single",
@@ -36,8 +54,85 @@ describe("Type tests", () => {
           dataType: {
             type: "boolean",
             boolean: {},
-          }
-        }
+          },
+        },
+      },
+    });
+  });
+
+  it("should have the same types as a chat definition", () => {
+    const schema = convertJsonSchemaToCustomSchema(
+      "chat",
+      CHAT_DEFINITION.chat.input,
+      CHAT_DEFINITION.chat.output
+    );
+    expect(schema).toStrictEqual({
+      functionName: "chat",
+      inputs: [
+        {
+          name: "messages",
+          required: true,
+          dataType: {
+            type: "list",
+            list: {
+              elementsType: {
+                type: "anonymousCustomType",
+                anonymousCustomType: {
+                  fields: {
+                    role: {
+                      type: "string",
+                      string: {},
+                    },
+                    content: {
+                      type: "string",
+                      string: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+          constraints: [],
+        },
+        {
+          name: "temperature",
+          required: true,
+          dataType: {
+            type: "float",
+            float: {},
+          },
+          constraints: [],
+        },
+        {
+          name: "max_tokens",
+          required: true,
+          dataType: {
+            type: "float",
+            float: {},
+          },
+          constraints: [],
+        },
+      ],
+      output: {
+        type: "single",
+        single: {
+          dataType: {
+            type: "anonymousCustomType",
+            anonymousCustomType: {
+              fields: {
+                messages: {
+                  type: "list",
+                  list: {
+                    elementsType: {
+                      type: "string",
+                      string: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     });
   });


### PR DESCRIPTION
Typo in the list type definition meant that registration for any functions using the list type would fail to deserialize. Correcting the error and adding a test.