### PR TITLE
Add source checking to the compute module api

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ const myModule = new ComputeModule({
   sources: {
     MyApi: {
       credentials: ["MyCredential"]
-    }
+    },
+    // You can validate the source, without validating the credential
+    AnotherApi: {}
   }
 });
 
@@ -115,6 +117,9 @@ myModule.getCredential("MyApi", "YourCredential");
 
 // ✅ Passes type checking
 myModule.getCredential("MyApi", "MyCredential");
+
+// ✅ As there are no known credentials, any string can be passed to this source
+myModule.getCredential("AnotherApi", "AnyString");
 ```
 
 If not provided, getCredential will do no type validation compile-time and the instance will not validate at run-time.

--- a/README.md
+++ b/README.md
@@ -100,16 +100,24 @@ Sources can be validated on startup by declaring them in the compute module opti
 
 ```ts
 const myModule = new ComputeModule({
-  // Will throw if MyApi has not been mounted
-  sources: ["MyApi"]
+  // Will throw if MyApi with credential MyCredential has not been mounted
+  sources: {
+    MyApi: {
+      credentials: ["MyCredential"]
+    }
+  }
 });
 
 // ❌ Will throw a type error
+myModule.getCredential("YourApi", "YourCredential");
 myModule.getCredential("YourApi", "MyCredential");
+myModule.getCredential("MyApi", "YourCredential");
 
 // ✅ Passes type checking
 myModule.getCredential("MyApi", "MyCredential");
 ```
+
+If not provided, getCredential will do no type validation compile-time and the instance will not validate at run-time.
 
 ### Retrieving environment details
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ Sources can be used to store secrets for use within a Compute Module, they preve
 const myCredential = myModule.getCredential("MySourceApiName", "MyCredential");
 ```
 
+Sources can be validated on startup by declaring them in the compute module options:
+
+```ts
+const myModule = new ComputeModule({
+  // Will throw if MyApi has not been mounted
+  sources: ["MyApi"]
+});
+
+// ❌ Will throw a type error
+myModule.getCredential("YourApi", "MyCredential");
+
+// ✅ Passes type checking
+myModule.getCredential("MyApi", "MyCredential");
+```
+
 ### Retrieving environment details
 
 At runtime, you can retrieve details about the execution environment, which is useful for authenticating around services available:

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 
 const computeModule = new ComputeModule({
   logger: console,
+  sources: ["TestApi"],
   definitions: {
     chat: {
       input: Type.Object({
@@ -98,7 +99,7 @@ if (computeModule.environment.type === "pipelines") {
     })
     .register("getCredential", async (v) => {
       return (
-        (await computeModule.getCredential(v.source, v.key)) ?? "Not found"
+        (await computeModule.getCredential(v.source as "TestApi", v.key)) ?? "Not found"
       );
     })
     .register("openFile", async (v) => {

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -3,7 +3,7 @@ import { Type } from "@sinclair/typebox";
 
 const computeModule = new ComputeModule({
   logger: console,
-  sources: ["TestApi"],
+  sources: ["MyApi"],
   definitions: {
     chat: {
       input: Type.Object({
@@ -74,7 +74,7 @@ if (computeModule.environment.type === "pipelines") {
   );
   console.log(
     `Logging credential "TestSecret" on "TestApi"`,
-    computeModule.getCredential("TestApi", "TestSecret")
+    computeModule.getCredential("MyApi", "TestSecret")
   );
   console.log(
     `Logging streamProxyApi location`,
@@ -99,7 +99,7 @@ if (computeModule.environment.type === "pipelines") {
     })
     .register("getCredential", async (v) => {
       return (
-        (await computeModule.getCredential(v.source as "TestApi", v.key)) ?? "Not found"
+        (await computeModule.getCredential(v.source as "MyApi", v.key)) ?? "Not found"
       );
     })
     .register("openFile", async (v) => {

--- a/example-module/src/index.ts
+++ b/example-module/src/index.ts
@@ -3,7 +3,12 @@ import { Type } from "@sinclair/typebox";
 
 const computeModule = new ComputeModule({
   logger: console,
-  sources: ["MyApi"],
+  sources: {
+    MyApi: {
+      credentials: ["TestSecret"],
+    },
+    YourApi: {}
+  },
   definitions: {
     chat: {
       input: Type.Object({
@@ -99,7 +104,7 @@ if (computeModule.environment.type === "pipelines") {
     })
     .register("getCredential", async (v) => {
       return (
-        (await computeModule.getCredential(v.source as "MyApi", v.key)) ?? "Not found"
+        (await computeModule.getCredential(v.source as "YourApi", v.key)) ?? "Not found"
       );
     })
     .register("openFile", async (v) => {

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -85,8 +85,6 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
   private resourceAliases: ResourceAliases | null;
   private logger?: Logger;
   private queryRunner: QueryRunner<O["definitions"]>;
-  private definitions?: O["definitions"];
-  private shouldAutoRegister: boolean;
 
   private listeners: Partial<{
     [K in keyof O["definitions"]]: QueryListener<Pick<O["definitions"], K>>;
@@ -102,8 +100,6 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
   }: O) {
     this.logger =
       logger != null ? loggerToInstanceLogger(logger, instanceId) : undefined;
-    this.definitions = definitions;
-    this.shouldAutoRegister = isAutoRegistered ?? true;
 
     const sourceCredentialsPath = process.env[ComputeModule.SOURCE_CREDENTIALS];
     this.sourceCredentials =
@@ -143,7 +139,7 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
       return;
     }
 
-    this.initialize();
+    this.initialize(definitions, isAutoRegistered ?? true);
   }
 
   /**
@@ -154,7 +150,9 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
    */
   public register<T extends keyof O["definitions"]>(
     queryName: T,
-    listener: (data: Static<O["definitions"][T]["input"]>) => Promise<Static<O["definitions"][T]["output"]>>
+    listener: (
+      data: Static<O["definitions"][T]["input"]>
+    ) => Promise<Static<O["definitions"][T]["output"]>>
   ) {
     this.listeners[queryName] = { type: "response", listener };
     return this;
@@ -168,7 +166,10 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
    */
   public registerStreaming<T extends keyof O["definitions"]>(
     queryName: T,
-    listener: (data: Static<O["definitions"][T]["input"]>, writable: Writable) => void
+    listener: (
+      data: Static<O["definitions"][T]["input"]>,
+      writable: Writable
+    ) => void
   ) {
     this.listeners[queryName] = { type: "streaming", listener };
     return this;
@@ -250,7 +251,10 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
     };
   }
 
-  private initialize() {
+  private initialize(
+    definitions: O["definitions"],
+    shouldAutoRegister: boolean
+  ) {
     const computeModuleApi = new ComputeModuleApi({
       getJobUri: process.env[ComputeModule.GET_JOB_URI] ?? "",
       postResultUri: process.env[ComputeModule.POST_RESULT_URI] ?? "",
@@ -267,8 +271,8 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
 
     this.queryRunner.on("responsive", () => {
       this.logger?.info("Module is responsive");
-      if (this.definitions && this.shouldAutoRegister) {
-        const schemas = Object.entries(this.definitions).map(
+      if (definitions && shouldAutoRegister) {
+        const schemas = Object.entries(definitions).map(
           ([queryName, query]) =>
             convertJsonSchemaToCustomSchema(
               queryName,

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -4,7 +4,10 @@ import {
   QueryRunner,
   QueryListener,
 } from "./QueryRunner";
-import { ComputeModuleApi, formatAxiosErrorResponse } from "./api/ComputeModuleApi";
+import {
+  ComputeModuleApi,
+  formatAxiosErrorResponse,
+} from "./api/ComputeModuleApi";
 import { convertJsonSchemaToCustomSchema } from "./api/convertJsonSchematoFoundrySchema";
 import { Static } from "@sinclair/typebox";
 import { SourceCredentials } from "./sources/SourceCredentials";
@@ -18,7 +21,10 @@ import * as fs from "fs";
 import { isAxiosError } from "axios";
 import { Writable } from "stream";
 
-export interface ComputeModuleOptions<M extends QueryResponseMapping = any, S extends string = string> {
+export interface ComputeModuleOptions<
+  M extends QueryResponseMapping = any,
+  S extends string = string
+> {
   /**
    * Definitions for the queries that the module will respond to, defined using typebox.
    * @example
@@ -53,10 +59,16 @@ export interface ComputeModuleOptions<M extends QueryResponseMapping = any, S ex
   /**
    * Expected sources to be mounted on the module, if provided will throw an error if the sources are not mounted.
    */
-  sources?: S[];
+  sources?: {
+    [K in S]: SourceOptions;
+  };
 }
 
-export class ComputeModule<M extends QueryResponseMapping, S extends string> {
+type SourceOptions<S extends string = string> = {
+  credentials?: S[];
+};
+
+export class ComputeModule<const O extends ComputeModuleOptions> {
   // Environment variables
   private static GET_JOB_URI = "GET_JOB_URI";
   private static POST_RESULT_URI = "POST_RESULT_URI";
@@ -72,12 +84,12 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
   private sourceCredentials: SourceCredentials | null;
   private resourceAliases: ResourceAliases | null;
   private logger?: Logger;
-  private queryRunner: QueryRunner<M>;
-  private definitions?: M;
+  private queryRunner: QueryRunner<O["definitions"]>;
+  private definitions?: O["definitions"];
   private shouldAutoRegister: boolean;
 
   private listeners: Partial<{
-    [K in keyof M]: QueryListener<Pick<M, K>>;
+    [K in keyof O["definitions"]]: QueryListener<Pick<O["definitions"], K>>;
   }> = {};
   private defaultListener?: (data: any, queryName: string) => Promise<any>;
 
@@ -86,8 +98,8 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
     instanceId,
     definitions,
     isAutoRegistered,
-    sources
-  }: ComputeModuleOptions<M, S>) {
+    sources,
+  }: O) {
     this.logger =
       logger != null ? loggerToInstanceLogger(logger, instanceId) : undefined;
     this.definitions = definitions;
@@ -99,13 +111,20 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
         ? new SourceCredentials(sourceCredentialsPath)
         : null;
 
-    if(sources != null) {
-      sources.forEach((source) => {
+    if (sources != null) {
+      Object.keys(sources).forEach((source) => {
         if (!this.sourceCredentials?.hasSource(source)) {
           throw new Error(
             `Source ${source} not found in source credentials. Ensure you have mounted the correct sources.`
           );
         }
+        sources[source].credentials?.forEach((credential) => {
+          if (!this.sourceCredentials?.getCredential(source, credential)) {
+            throw new Error(
+              `Credential ${credential} not found in source ${source}. Ensure you have mounted the correct sources.`
+            );
+          }
+        });
       });
     }
 
@@ -113,7 +132,7 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
     this.resourceAliases =
       resourceAliasMap != null ? new ResourceAliases(resourceAliasMap) : null;
 
-    this.queryRunner = new QueryRunner<M>(
+    this.queryRunner = new QueryRunner<O["definitions"]>(
       this.listeners,
       this.defaultListener,
       this.logger
@@ -133,9 +152,9 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
    * @param listener Function to run when the query is received
    * @returns
    */
-  public register<T extends keyof M>(
+  public register<T extends keyof O["definitions"]>(
     queryName: T,
-    listener: (data: Static<M[T]["input"]>) => Promise<Static<M[T]["output"]>>
+    listener: (data: Static<O["definitions"][T]["input"]>) => Promise<Static<O["definitions"][T]["output"]>>
   ) {
     this.listeners[queryName] = { type: "response", listener };
     return this;
@@ -147,12 +166,9 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
    * @param listener Function to run when the query is received
    * @returns
    */
-  public registerStreaming<T extends keyof M>(
+  public registerStreaming<T extends keyof O["definitions"]>(
     queryName: T,
-    listener: (
-      data: Static<M[T]["input"]>,
-      writable: Writable
-    ) => void
+    listener: (data: Static<O["definitions"][T]["input"]>, writable: Writable) => void
   ) {
     this.listeners[queryName] = { type: "streaming", listener };
     return this;
@@ -182,10 +198,14 @@ export class ComputeModule<M extends QueryResponseMapping, S extends string> {
   /**
    * Sources can be used to store secrets for use within a Compute Module, they prevent you from having to put secrets in your container or in plaintext in the job specification.
    */
-  public getCredential(
-    sourceApiName: S,
-    credentialName: string
-  ): string | null {
+  public getCredential<
+    T_Source extends O extends { sources: infer S } ? keyof S : string,
+    T_Credential extends O extends {
+      sources: { [K in T_Source]: SourceOptions<infer C> };
+    }
+      ? C
+      : string
+  >(sourceApiName: T_Source, credentialName: T_Credential): string | null {
     if (this.sourceCredentials == null) {
       throw new Error(
         "No source credentials mounted. This implies the SOURCE_CREDENTIALS environment variable has not been set, ensure you have set sources mounted on the Compute Module."

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -18,7 +18,7 @@ import * as fs from "fs";
 import { isAxiosError } from "axios";
 import { Writable } from "stream";
 
-export interface ComputeModuleOptions<M extends QueryResponseMapping = any> {
+export interface ComputeModuleOptions<M extends QueryResponseMapping = any, S extends string = string> {
   /**
    * Definitions for the queries that the module will respond to, defined using typebox.
    * @example
@@ -50,9 +50,13 @@ export interface ComputeModuleOptions<M extends QueryResponseMapping = any> {
    * Can be set to false to enable typesafety without registering the queries.
    */
   isAutoRegistered?: boolean;
+  /**
+   * Expected sources to be mounted on the module, if provided will throw an error if the sources are not mounted.
+   */
+  sources?: S[];
 }
 
-export class ComputeModule<M extends QueryResponseMapping> {
+export class ComputeModule<M extends QueryResponseMapping, S extends string> {
   // Environment variables
   private static GET_JOB_URI = "GET_JOB_URI";
   private static POST_RESULT_URI = "POST_RESULT_URI";
@@ -82,7 +86,8 @@ export class ComputeModule<M extends QueryResponseMapping> {
     instanceId,
     definitions,
     isAutoRegistered,
-  }: ComputeModuleOptions<M>) {
+    sources
+  }: ComputeModuleOptions<M, S>) {
     this.logger =
       logger != null ? loggerToInstanceLogger(logger, instanceId) : undefined;
     this.definitions = definitions;
@@ -93,6 +98,16 @@ export class ComputeModule<M extends QueryResponseMapping> {
       sourceCredentialsPath != null
         ? new SourceCredentials(sourceCredentialsPath)
         : null;
+
+    if(sources != null) {
+      sources.forEach((source) => {
+        if (!this.sourceCredentials?.hasSource(source)) {
+          throw new Error(
+            `Source ${source} not found in source credentials. Ensure you have mounted the correct sources.`
+          );
+        }
+      });
+    }
 
     const resourceAliasMap = process.env[ComputeModule.RESOURCE_ALIAS_MAP];
     this.resourceAliases =
@@ -168,7 +183,7 @@ export class ComputeModule<M extends QueryResponseMapping> {
    * Sources can be used to store secrets for use within a Compute Module, they prevent you from having to put secrets in your container or in plaintext in the job specification.
    */
   public getCredential(
-    sourceApiName: string,
+    sourceApiName: S,
     credentialName: string
   ): string | null {
     if (this.sourceCredentials == null) {

--- a/typescript-compute-module/src/sources/SourceCredentials.ts
+++ b/typescript-compute-module/src/sources/SourceCredentials.ts
@@ -19,6 +19,10 @@ export class SourceCredentials {
     return this.sourceCredentials[sourceApiName]?.[credentialName] ?? null;
   }
 
+  public hasSource(sourceApiName: string): boolean {
+    return this.sourceCredentials[sourceApiName] != null;
+  }
+
   private get sourceCredentials(): SourceCredentialsFile {
     return (this._sourceCredentials ??= this.loadSourceCredentials());
   }


### PR DESCRIPTION
Sources are not checked at compile type, so you can put any string in and hope for a source. This allows users to declaratively define the environment they expect their code to run in, and automatically throws if the environment is wrong.