### PR TITLE
Remove Node.JS types from the API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         },
         "typescript-compute-module": {
             "name": "@palantir/compute-module",
-            "version": "0.1.3",
+            "version": "0.2.5",
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.32.35",

--- a/typescript-compute-module/package.json
+++ b/typescript-compute-module/package.json
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.32.35",
+    "@types/node": "^20.11.17",
     "axios": "^1.6.7",
     "js-yaml": "^3.14.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.11.17",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.3",
     "typescript": "^5.3.3"

--- a/typescript-compute-module/package.json
+++ b/typescript-compute-module/package.json
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.32.35",
-    "@types/node": "^20.11.17",
     "axios": "^1.6.7",
     "js-yaml": "^3.14.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.11.17",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.3",
     "typescript": "^5.3.3"

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -16,7 +16,6 @@ import {
 } from "./services/getFoundryServices";
 import * as fs from "fs";
 import { isAxiosError } from "axios";
-import { Writable } from "stream";
 
 export interface ComputeModuleOptions<M extends QueryResponseMapping = any> {
   /**
@@ -136,7 +135,10 @@ export class ComputeModule<M extends QueryResponseMapping> {
     queryName: T,
     listener: (
       data: Static<M[T]["input"]>,
-      writable: Writable
+      writable: {
+        write: (chunk: any) => void;
+        end: (chunk: any) => void;
+      }
     ) => void
   ) {
     this.listeners[queryName] = { type: "streaming", listener };

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -136,8 +136,8 @@ export class ComputeModule<M extends QueryResponseMapping> {
     listener: (
       data: Static<M[T]["input"]>,
       writable: {
-        write: (chunk: any) => void;
-        end: (chunk: any) => void;
+        write: (chunk: Buffer | Uint8Array | string) => void;
+        end: () => void;
       }
     ) => void
   ) {

--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -1,9 +1,12 @@
-import { AxiosError, HttpStatusCode, isAxiosError } from "axios";
+import { HttpStatusCode, isAxiosError } from "axios";
 import { Logger } from "./logger";
 import { Static, TObject } from "@sinclair/typebox";
-import { ComputeModuleApi, formatAxiosErrorResponse } from "./api/ComputeModuleApi";
+import {
+  ComputeModuleApi,
+  formatAxiosErrorResponse,
+} from "./api/ComputeModuleApi";
 import { SupportedTypeboxTypes } from "./api/convertJsonSchematoFoundrySchema";
-import { PassThrough, Writable } from "stream";
+import { PassThrough } from "stream";
 
 export interface QueryResponseMapping {
   [queryType: string]: {
@@ -12,20 +15,29 @@ export interface QueryResponseMapping {
   };
 }
 
-export type QueryListener<M extends QueryResponseMapping> = {
-  type: "response";
-  listener: ResponseQueryListener<M>;
-} | {
-  type: "streaming";
-  listener: StreamingQueryListener<M>;
-};
+export type QueryListener<M extends QueryResponseMapping> =
+  | {
+      type: "response";
+      listener: ResponseQueryListener<M>;
+    }
+  | {
+      type: "streaming";
+      listener: StreamingQueryListener<M>;
+    };
 
-export type StreamingQueryListener<M extends QueryResponseMapping> = <T extends keyof M>(
+export type StreamingQueryListener<M extends QueryResponseMapping> = <
+  T extends keyof M
+>(
   message: Static<M[T]["input"]>,
-  responseStream: Writable
+  responseStream: {
+    write: (data: any) => void;
+    end: () => void;
+  }
 ) => void;
 
-export type ResponseQueryListener<M extends QueryResponseMapping> = <T extends keyof M>(
+export type ResponseQueryListener<M extends QueryResponseMapping> = <
+  T extends keyof M
+>(
   message: Static<M[T]["input"]>
 ) => Promise<Static<M[T]["output"]>>;
 
@@ -40,14 +52,17 @@ export class QueryRunner<M extends QueryResponseMapping> {
     }>,
     private defaultListener?: (query: any, queryType: string) => Promise<any>,
     private readonly logger?: Logger
-  ) { }
+  ) {}
 
   async run(computeModuleApi: ComputeModuleApi) {
     while (true) {
       try {
         const jobRequest = await computeModuleApi.getJobRequest();
 
-        if (!this.isResponsive && jobRequest.status.toString().startsWith("2")) {
+        if (
+          !this.isResponsive &&
+          jobRequest.status.toString().startsWith("2")
+        ) {
           // If this is the first job, set the module as responsive
           this.setResponsive();
         }
@@ -59,9 +74,9 @@ export class QueryRunner<M extends QueryResponseMapping> {
           const listener = this.listeners[queryType];
 
           if (listener?.type === "response") {
-            listener.listener(query).then((response) =>
-              computeModuleApi.postResult(jobId, response)
-            );
+            listener
+              .listener(query)
+              .then((response) => computeModuleApi.postResult(jobId, response));
           } else if (listener?.type === "streaming") {
             const writable = new PassThrough();
             listener.listener(query, writable);

--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -30,7 +30,7 @@ export type StreamingQueryListener<M extends QueryResponseMapping> = <
 >(
   message: Static<M[T]["input"]>,
   responseStream: {
-    write: (data: any) => void;
+    write: (chunk: Buffer | Uint8Array | string) => void;
     end: () => void;
   }
 ) => void;


### PR DESCRIPTION
Node.JS types were being used in the API, meaning that users would have to import @types/node to use the library.