### PR TITLE
Catch and handle blocking function errors

### DIFF
--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -76,7 +76,11 @@ export class QueryRunner<M extends QueryResponseMapping> {
           if (listener?.type === "response") {
             listener
               .listener(query)
-              .then((response) => computeModuleApi.postResult(jobId, response));
+              .then((response) => computeModuleApi.postResult(jobId, response))
+              .catch((error) => {
+                this.logger?.error(`Error executing job - ID: ${jobId} Reason: ${error}`);
+                computeModuleApi.postResult(jobId, QueryRunner.getFailedQueryResult(error));
+              });
           } else if (listener?.type === "streaming") {
             const writable = new PassThrough();
             listener.listener(query, writable);
@@ -125,5 +129,12 @@ export class QueryRunner<M extends QueryResponseMapping> {
     defaultListener: (query: any, queryType: string) => Promise<any>
   ) {
     this.defaultListener = defaultListener;
+  }
+
+  private static getFailedQueryResult(error: any): Record<string, string> {
+    return { "error": error.toString(),
+             ...(error instanceof Error &&
+              { "error": error.name, "reason": error.message })
+    };
   }
 }


### PR DESCRIPTION
Errors in the promise were not catched - this meant that a query to a blocking function would appear to load infinitely and time out when an error occured on the FE, even after it has been executed.

This change makes the TS SDK behaviour in line with the Python SDK behaviour.