### PR TITLE
Move methods to static where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ new ComputeModule()
   .default(() => ({ error: "Unsupported query name" }));
 ```
 
-
 ### Schema registration
 
 Definitions can be generated using [typebox](https://github.com/sinclairzx81/typebox) allowing the Compute Module to register functions at runtime, while maintaining typesafety at compile time.
@@ -80,7 +79,9 @@ myModule.register("addOne", async ({ value }) => ({ value: n + 1 }));
 Compute Modules can interact with resources in their execution environment, within Palantir Foundry these are defined as inputs and outputs on the Compute Module spec. Resource identifiers can be unique to the execution environment, so using aliases allows your code to maintain a static reference to known resources. To receive the identifier for an aliases resource, use the `getResource` method.
 
 ```ts
-const resourceId = myModule.getResource("myResourceAlias");
+import { ComputeModule } from "@palantir/compute-module";
+
+const resourceId = ComputeModule.getResource("myResourceAlias");
 const result = await someDataFetcherForId(resourceId);
 ```
 
@@ -129,8 +130,13 @@ If not provided, getCredential will do no type validation compile-time and the i
 At runtime, you can retrieve details about the execution environment, which is useful for authenticating around services available:
 
 ```ts
-const token =
-  myModule.environment.type === "pipelines" ? myModule.environment.buildToken : undefined;
+import { ComputeModule } from "@palantir/compute-module";
+
+const environment = ComputeModule.getEnvironment();
+const buildToken =
+  environment.type === "pipelines" ? environment.buildToken : undefined;
+
+const thirdPartyApplicationCredentials = environment.type === "functions" ? environment.thirdPartyApplication : undefined;
 ```
 
 ### Retrieving Foundry services

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -67,6 +67,11 @@ type SourceOptions<S extends string = string> = {
   credentials?: S[];
 };
 
+const resourceAliasMapPath = process.env["RESOURCE_ALIAS_MAP"];
+const resourceAliases =
+  resourceAliasMapPath != null
+    ? new ResourceAliases(resourceAliasMapPath)
+    : null;
 export class ComputeModule<const O extends ComputeModuleOptions> {
   // Environment variables
   private static GET_JOB_URI = "GET_JOB_URI";
@@ -75,13 +80,13 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
 
   // Known mounted files
   private static SOURCE_CREDENTIALS = "SOURCE_CREDENTIALS";
-  private static RESOURCE_ALIAS_MAP = "RESOURCE_ALIAS_MAP";
   private static DEFAULT_CA_PATH = "DEFAULT_CA_PATH";
   private static MODULE_AUTH_TOKEN = "MODULE_AUTH_TOKEN";
   private static BUILD2_TOKEN = "BUILD2_TOKEN";
+  private static CLIENT_ID = "CLIENT_ID";
+  private static CLIENT_SECRET = "CLIENT_SECRET";
 
   private sourceCredentials: SourceCredentials | null;
-  private resourceAliases: ResourceAliases | null;
   private logger?: Logger;
   private queryRunner: QueryRunner<O["definitions"]>;
 
@@ -122,10 +127,6 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
         });
       });
     }
-
-    const resourceAliasMap = process.env[ComputeModule.RESOURCE_ALIAS_MAP];
-    this.resourceAliases =
-      resourceAliasMap != null ? new ResourceAliases(resourceAliasMap) : null;
 
     this.queryRunner = new QueryRunner<O["definitions"]>(
       this.listeners,
@@ -218,29 +219,29 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
   }
 
   /**
+   * At runtime, you can retrieve the api paths for known Foundry services, this allows you to call those endpoints without using a source to ingress back into the platform.
+   */
+  public static getServiceApi(service: FoundryService): string | undefined {
+    return getFoundryServices()[service];
+  }
+
+  /**
    * Compute Modules can interact with resources in their execution environment, within Palantir Foundry these are defined as inputs and outputs on the Compute Module spec. Resource identifiers can be unique to the execution environment,
    * so using aliases allows your code to maintain a static reference to known resources.
    */
-  public getResource(alias: string): Resource | null {
-    if (this.resourceAliases == null) {
+  public static getResource(alias: string): Resource | null {
+    if (resourceAliases == null) {
       throw new Error(
         "No resource aliases mounted. This implies the RESOURCE_ALIAS_MAP environment variable has not been set, ensure you have set resources mounted on the Compute Module."
       );
     }
-    return this.resourceAliases.getAlias(alias);
-  }
-
-  /**
-   * At runtime, you can retrieve the api paths for known Foundry services, this allows you to call those endpoints without using a source to ingress back into the platform.
-   */
-  public getServiceApi(service: FoundryService): string {
-    return getFoundryServices()[service];
+    return resourceAliases.getAlias(alias);
   }
 
   /**
    * Returns the environment and tokens for the current execution mode
    */
-  public get environment(): Environment {
+  public static getEnvironment(): Environment {
     const buildTokenPath = process.env[ComputeModule.BUILD2_TOKEN];
     if (buildTokenPath != null) {
       return {
@@ -248,9 +249,48 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
         buildToken: fs.readFileSync(buildTokenPath, "utf-8"),
       };
     }
+    const maybeClientId = process.env[ComputeModule.CLIENT_ID];
+    const maybeClientSecret = process.env[ComputeModule.CLIENT_SECRET];
     return {
       type: "functions",
+      thirdPartyApplication:
+        maybeClientId != null && maybeClientSecret != null
+          ? {
+              clientId: maybeClientId,
+              clientSecret: maybeClientSecret,
+            }
+          : undefined,
     };
+  }
+
+  /**
+   * @deprecated Use `ComputeModule.getServiceApi()` instead
+   * This method is deprecated and will be removed in future versions.
+   *
+   * Returns the api path for a given Foundry service
+   */
+  public getServiceApi(service: FoundryService): string | undefined {
+    return ComputeModule.getServiceApi(service);
+  }
+
+  /**
+   * @deprecated Use `ComputeModule.getResource()` instead
+   * This method is deprecated and will be removed in future versions.
+   *
+   * Returns the resource for a given alias, if the alias is not found, returns null
+   */
+  public getResource(alias: string): Resource | null {
+    return ComputeModule.getResource(alias);
+  }
+
+  /**
+   * @deprecated Use `ComputeModule.getEnvironment()` instead
+   * This method is deprecated and will be removed in future versions.
+   *
+   * Returns the environment and tokens for the current execution mode
+   */
+  public get environment(): Environment {
+    return ComputeModule.getEnvironment();
   }
 
   private initialize(
@@ -258,7 +298,7 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
     shouldAutoRegister: boolean
   ) {
     const defaultCAPath = process.env[ComputeModule.DEFAULT_CA_PATH];
-    
+
     const computeModuleApi = new ComputeModuleApi({
       getJobUri: process.env[ComputeModule.GET_JOB_URI] ?? "",
       postResultUri: process.env[ComputeModule.POST_RESULT_URI] ?? "",
@@ -276,13 +316,8 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
     this.queryRunner.on("responsive", () => {
       this.logger?.info("Module is responsive");
       if (definitions && shouldAutoRegister) {
-        const schemas = Object.entries(definitions).map(
-          ([queryName, query]) =>
-            convertJsonSchemaToCustomSchema(
-              queryName,
-              query.input,
-              query.output
-            )
+        const schemas = Object.entries(definitions).map(([queryName, query]) =>
+          convertJsonSchemaToCustomSchema(queryName, query.input, query.output)
         );
 
         this.logger?.info(`Posting schemas:${JSON.stringify(schemas)}`);

--- a/typescript-compute-module/src/environment/types.ts
+++ b/typescript-compute-module/src/environment/types.ts
@@ -9,4 +9,14 @@ export interface PipelinesEnvironment {
 
 export interface FunctionsEnvironment {
   type: "functions";
+  /**
+   * If the compute module is in Application mode, this will provide the client ID and client secret
+   * for the third-party application that is being used to authenticate with Foundry.
+   * 
+   * These are provided by the environment variables CLIENT_ID and CLIENT_SECRET.
+   */
+  thirdPartyApplication?: {
+    clientId: string;
+    clientSecret: string;
+  }
 }

--- a/typescript-compute-module/src/services/getFoundryServices.ts
+++ b/typescript-compute-module/src/services/getFoundryServices.ts
@@ -19,7 +19,7 @@ export enum FoundryService {
   MIO = "foundry_mio",
 }
 
-let cachedServices: Record<FoundryService, string> | null = null;
+let cachedServices: Record<FoundryService, string | undefined> | null = null;
 /**
  * Used to discover the location of Foundry services for interaction with the Foundry API
  */
@@ -37,7 +37,7 @@ export const getFoundryServices = () => {
         key,
         value[0],
       ])
-    ) as Record<FoundryService, string>;
+    ) as Record<FoundryService, string | undefined>;
   }
   return cachedServices;
 };


### PR DESCRIPTION
In many cases, you may not use the ComputeModule to actually define any functions. In this world it's nicer to be able to pull the static implementations from the ComputeModule class rather than instantiate it just for the convenience methods