### PR TITLE
Support Optional types for function inference

### DIFF
--- a/typescript-compute-module/src/api/convertJsonSchematoFoundrySchema.ts
+++ b/typescript-compute-module/src/api/convertJsonSchematoFoundrySchema.ts
@@ -40,7 +40,15 @@ export function convertJsonSchemaToCustomSchema(
 }
 
 function convertJsonType(jsonType: TSchema): Schema.DataType {
-  if (TypeGuard.IsObject(jsonType)) {
+  if (TypeGuard.IsOptional(jsonType)) {
+    return {
+      type: "optionalType",
+      optionalType: {
+        wrappedType: convertJsonType(jsonType.type)
+      }
+    }
+  }
+  else if (TypeGuard.IsObject(jsonType)) {
     return {
       type: "anonymousCustomType",
       anonymousCustomType: {

--- a/typescript-compute-module/src/api/schemaTypes.ts
+++ b/typescript-compute-module/src/api/schemaTypes.ts
@@ -22,7 +22,7 @@ export namespace Schema {
     }
   }
 
-  export type DataType = BooleanType | IntegerType | FloatType | StringType | ListType | AnonymousCustomType;
+  export type DataType = BooleanType | IntegerType | FloatType | StringType | ListType | AnonymousCustomType | OptionalType;
 
   export type BooleanType = {
     type: "boolean";
@@ -58,5 +58,12 @@ export namespace Schema {
           [key: string]: DataType;
         }
       };
+  }
+
+  export type OptionalType = {
+    type: "optionalType";
+    optionalType: {
+      wrappedType: DataType;
+    }
   }
 }

--- a/typescript-compute-module/src/api/tests/convertJsonSchemaToCustomSchema.test.ts
+++ b/typescript-compute-module/src/api/tests/convertJsonSchemaToCustomSchema.test.ts
@@ -21,6 +21,7 @@ const CHAT_DEFINITION = {
       ),
       temperature: Type.Number(),
       max_tokens: Type.Number(),
+      optionalField: Type.Optional(Type.String())
     }),
     output: Type.Object({
       messages: Type.Array(Type.String()),
@@ -112,6 +113,20 @@ describe("Type tests", () => {
           },
           constraints: [],
         },
+        {
+          name: "optionalField",
+          required: false,
+          dataType: {
+            type: "optionalType",
+            optionalType: {
+              wrappedType: {
+                type: "string",
+                string: {}
+              }
+            }
+          },
+          constraints: [],
+        }
       ],
       output: {
         type: "single",


### PR DESCRIPTION
There was no support for Optional TypeBox types, meaning runtime function schema inference always indicated that parameters were non-Nullable. Now, using `Type.Optional()`, the nested type will be inferred as Nullable.