### PR TITLE
Use trusted publishers for NPM publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,3 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Remove the explicit NPM auth token and use the GitHub Actions OIDC token to take advantage of [trusted publishers support][1]. I've already made the necessary changes on the NPM side.

[1]: https://docs.npmjs.com/trusted-publishers