### PR TITLE
RC release support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,10 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - name: Publish to npm
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == *"-rc"* ]]; then
+            npm publish --provenance --access public --tag rc
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         run: cp ../*.md .
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - name: Publish to npm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="right">
-<a href="https://autorelease.general.dmz.palantir.tech/palantir/typescript-compute-module"><img src="https://img.shields.io/badge/Perform%20an-Autorelease-success.svg" alt="Autorelease"></a>
+<!-- <a href="https://autorelease.general.dmz.palantir.tech/palantir/typescript-compute-module"><img src="https://img.shields.io/badge/Perform%20an-Autorelease-success.svg" alt="Autorelease"></a> -->
 </p>
 
 # @palantir/compute-module

--- a/typescript-compute-module/package.json
+++ b/typescript-compute-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@palantir/compute-module",
-  "version": "0.2.10",
+  "version": "0.2.11-rc1",
   "description": "Typescript binding for implementing the compute module API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Before this PR
npm treated `0.2.10-rc1` as a stable release since it's not strictly adhering to semver (e.g. `0.2.10-rc.1`)

## After this PR
Use a separate release tag so RC releases are not considered the 'latest' stable release

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

