### PR TITLE
SLS Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*.tgz

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Node.JS compatible implementation of the Palantir Compute Module specification.
   - [Pipelines Mode](#pipelines-mode)
     - [Retrieving aliases](#retrieving-aliases)
   - [General usage](#general-usage)
+    - [Logging](#logging)
     - [Retrieving source credentials](#retrieving-source-credentials)
     - [Retrieving environment details](#retrieving-environment-details)
     - [Retrieving Foundry services](#retrieving-foundry-services)
@@ -58,11 +59,11 @@ new ComputeModule()
 Definitions can be generated using [typebox](https://github.com/sinclairzx81/typebox) allowing the Compute Module to register functions at runtime, while maintaining typesafety at compile time.
 
 ```ts
-import { ComputeModule } from "@palantir/compute-module";
+import { ComputeModule, SlsLogger } from "@palantir/compute-module";
 import { Type } from "@sinclair/typebox";
 
 const myModule = new ComputeModule({
-  logger: console,
+  logger: new SlsLogger(),
   definitions: {
     addOne: {
       input: Type.Object({
@@ -92,6 +93,36 @@ const result = await someDataFetcherForId(resourceId);
 ## General usage
 
 The following features are available in both Pipelines and Functions mode in order to interact with Palantir Foundry:
+
+### Logging
+
+The `SlsLogger` provides structured logging that is viewable in the Foundry Compute Module logs UI:
+
+```ts
+import { ComputeModule, SlsLogger } from "@palantir/compute-module";
+import { Type } from "@sinclair/typebox";
+
+const logger = new SlsLogger();
+
+const myModule = new ComputeModule({
+  logger,
+  definitions: {
+    addOne: {
+      input: Type.Object({ value: Type.Number() }),
+      output: Type.Object({ value: Type.Number() }),
+    },
+  },
+});
+
+myModule.register("addOne", async ({ value }) => {
+  logger.info("Processing addOne", { input_value: String(value) });
+  return { value: value + 1 };
+});
+```
+
+Custom key-value pairs can be passed as the second argument to any log method (`debug`, `info`, `warn`, `error`) and will be added to the params of the log entry.
+
+Any object with `log`, `info`, `warn`, and `error` methods (e.g. `console`) is also accepted as a logger.
 
 ### Retrieving source credentials
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,14 @@ const result = await someDataFetcherForId(resourceId);
 
 The following features are available in both Pipelines and Functions mode in order to interact with Palantir Foundry:
 
-### Logging
+### Logging and SLS format
 
-The `SlsLogger` provides structured logging that is viewable in the Foundry Compute Module logs UI:
+Anything written to the stdout or stderr streams will be logged. However, we recommend using the `SlsLogger` to emit SLS-formatted logs.
+
+Standard Logging Specification (SLS) is a Palantir-defined structure for log messages. Since the structure of SLS logs is known, our infrastructure can programmatically parse SLS logs and neatly display values in the compute module log viewer's Tabular mode.
+Selecting SLS format will only display logs that adhere to the SLS structure. The `SlsLogger` provided by this SDK will automatically emit logs with the SLS structure.
+
+Use it as follows:
 
 ```ts
 import { ComputeModule, SlsLogger } from "@palantir/compute-module";

--- a/typescript-compute-module/src/ComputeModule.ts
+++ b/typescript-compute-module/src/ComputeModule.ts
@@ -20,6 +20,7 @@ import {
 } from "./services/getFoundryServices";
 import * as fs from "fs";
 import { isAxiosError } from "axios";
+import { SlsLogger } from "./logging/SlsLogger";
 
 export interface ComputeModuleOptions<
   M extends QueryResponseMapping = any,
@@ -103,8 +104,7 @@ export class ComputeModule<const O extends ComputeModuleOptions> {
     isAutoRegistered,
     sources,
   }: O) {
-    this.logger =
-      logger != null ? loggerToInstanceLogger(logger, instanceId) : undefined;
+    this.logger = loggerToInstanceLogger(logger ?? new SlsLogger(), instanceId)
 
     const sourceCredentialsPath = process.env[ComputeModule.SOURCE_CREDENTIALS];
     this.sourceCredentials =

--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -71,7 +71,7 @@ export class QueryRunner<M extends QueryResponseMapping> {
         if (jobRequest.status === HttpStatusCode.Ok) {
           const { query, queryType, jobId } =
             jobRequest.data.computeModuleJobV1;
-          this.logger?.info(`Job received - ID: ${jobId} Query: ${queryType}`);
+          this.logger?.info(`Job received - Query: ${queryType}`, { job_id: jobId });
           const listener = this.listeners[queryType];
 
           if (listener?.type === "response") {
@@ -80,7 +80,7 @@ export class QueryRunner<M extends QueryResponseMapping> {
               .then((response) => computeModuleApi.postResult(jobId, response))
               .catch((error) => {
                 const sanitizedError = isAxiosError(error) ? sanitizeAxiosError(error) : error;
-                this.logger?.error(`Error executing job - ID: ${jobId} Reason: ${sanitizedError}`);
+                this.logger?.error(`Error executing job: ${sanitizedError}`, { job_id: jobId });
                 computeModuleApi.postResult(jobId, QueryRunner.getFailedQueryResult(sanitizedError));
               });
           } else if (listener?.type === "streaming") {
@@ -98,7 +98,7 @@ export class QueryRunner<M extends QueryResponseMapping> {
               )
               .catch((error) => {
                 const sanitizedError = isAxiosError(error) ? sanitizeAxiosError(error) : error;
-                this.logger?.error(`Error executing default listener - ID: ${jobId} Reason: ${sanitizedError}`);
+                this.logger?.error(`Error executing default listener: ${sanitizedError}`, { job_id: jobId });
                 computeModuleApi.postResult(jobId, QueryRunner.getFailedQueryResult(sanitizedError));
               });
           } else {

--- a/typescript-compute-module/src/index.ts
+++ b/typescript-compute-module/src/index.ts
@@ -1,4 +1,5 @@
 export { ComputeModule } from "./ComputeModule";
 export type { ComputeModuleOptions } from "./ComputeModule";
-export type { Logger } from "./logger";
+export type { Logger, LogParams } from "./logger";
+export { SlsLogger } from "./logging/SlsLogger";
 export { FoundryService } from "./services/getFoundryServices";

--- a/typescript-compute-module/src/logger.ts
+++ b/typescript-compute-module/src/logger.ts
@@ -1,24 +1,45 @@
+export interface LogParams {
+  session_id?: string;
+  process_id?: string;
+  job_id?: string;
+  [key: string]: unknown;
+}
+
 export interface Logger {
-  log: (message: string) => void;
-  error: (message: string) => void;
-  info: (message: string) => void;
-  warn: (message: string) => void;
+  log: (message: string, params?: LogParams) => void;
+  debug?: (message: string, params?: LogParams) => void;
+  error: (message: string, params?: LogParams) => void;
+  info: (message: string, params?: LogParams) => void;
+  warn: (message: string, params?: LogParams) => void;
 }
 
 /**
- * Wraps a logger with an instance ID to differentiate logs from different instances if provided
+ * Wraps a logger with an instance ID prefix and base params injected into every log call.
  */
-export const loggerToInstanceLogger = (
+export function loggerToInstanceLogger(
   logger: Logger,
-  instanceId?: string
-): Logger => {
-  if (instanceId == null) {
-    return logger;
+  instanceId?: string,
+  baseParams?: LogParams
+): Logger {
+  const prefix = instanceId != null ? `[${instanceId}] ` : "";
+
+  function mergeParams(params?: LogParams): LogParams | undefined {
+    if (baseParams == null && params == null) return undefined;
+    return { ...baseParams, ...params };
   }
+
   return {
-    log: (message: string) => logger.log(`[${instanceId}] ${message}`),
-    error: (message: string) => logger.error(`[${instanceId}] ${message}`),
-    info: (message: string) => logger.info(`[${instanceId}] ${message}`),
-    warn: (message: string) => logger.warn(`[${instanceId}] ${message}`),
+    log: (message, params) =>
+      logger.log(`${prefix}${message}`, mergeParams(params)),
+    debug: logger.debug
+      ? (message, params) =>
+          logger.debug!(`${prefix}${message}`, mergeParams(params))
+      : undefined,
+    error: (message, params) =>
+      logger.error(`${prefix}${message}`, mergeParams(params)),
+    info: (message, params) =>
+      logger.info(`${prefix}${message}`, mergeParams(params)),
+    warn: (message, params) =>
+      logger.warn(`${prefix}${message}`, mergeParams(params)),
   };
-};
+}

--- a/typescript-compute-module/src/logger.ts
+++ b/typescript-compute-module/src/logger.ts
@@ -14,32 +14,26 @@ export interface Logger {
 }
 
 /**
- * Wraps a logger with an instance ID prefix and base params injected into every log call.
+ * Wraps a logger with an instance ID prefix injected into every log call.
  */
-export function loggerToInstanceLogger(
+export const loggerToInstanceLogger = (
   logger: Logger,
-  instanceId?: string,
-  baseParams?: LogParams
-): Logger {
+  instanceId?: string
+): Logger => {
   const prefix = instanceId != null ? `[${instanceId}] ` : "";
-
-  function mergeParams(params?: LogParams): LogParams | undefined {
-    if (baseParams == null && params == null) return undefined;
-    return { ...baseParams, ...params };
-  }
 
   return {
     log: (message, params) =>
-      logger.log(`${prefix}${message}`, mergeParams(params)),
+      logger.log(`${prefix}${message}`, params),
     debug: logger.debug
       ? (message, params) =>
-          logger.debug!(`${prefix}${message}`, mergeParams(params))
+          logger.debug!(`${prefix}${message}`, params)
       : undefined,
     error: (message, params) =>
-      logger.error(`${prefix}${message}`, mergeParams(params)),
+      logger.error(`${prefix}${message}`, params),
     info: (message, params) =>
-      logger.info(`${prefix}${message}`, mergeParams(params)),
+      logger.info(`${prefix}${message}`, params),
     warn: (message, params) =>
-      logger.warn(`${prefix}${message}`, mergeParams(params)),
+      logger.warn(`${prefix}${message}`, params),
   };
-}
+};

--- a/typescript-compute-module/src/logging/SlsLogger.ts
+++ b/typescript-compute-module/src/logging/SlsLogger.ts
@@ -1,0 +1,117 @@
+import { isMainThread, threadId } from "worker_threads";
+import type { Logger, LogParams } from "../logger";
+
+type SlsLogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+/**
+ * Logger that writes SLS-formatted JSON to stdout for telemetry sidecar parsing.
+ *
+ * The `origin` field is automatically set to the caller's `filename:line`,
+ * and the `thread` field reflects the current worker thread (matching the
+ * Python SDK's behaviour).
+ *
+ * @example
+ * ```typescript
+ * import { SlsLogger, ComputeModule } from "@palantir/compute-module";
+ *
+ * const module = new ComputeModule({
+ *   logger: new SlsLogger(),
+ *   definitions: { ... },
+ * });
+ * ```
+ */
+export class SlsLogger implements Logger {
+  private jobId: string = "";
+
+  /**
+   * Updates the job ID injected into every subsequent log entry's params.
+   */
+  setJobId(jobId: string): void {
+    this.jobId = jobId;
+  }
+
+  debug(message: string, params?: LogParams): void {
+    this.write("DEBUG", message, params);
+  }
+
+  log(message: string, params?: LogParams): void {
+    this.write("INFO", message, params);
+  }
+
+  info(message: string, params?: LogParams): void {
+    this.write("INFO", message, params);
+  }
+
+  warn(message: string, params?: LogParams): void {
+    this.write("WARN", message, params);
+  }
+
+  error(message: string, params?: LogParams): void {
+    this.write("ERROR", message, params);
+  }
+
+  private write(
+    level: SlsLogLevel,
+    message: string,
+    params?: LogParams
+  ): void {
+    const baseParams: Record<string, string> = {
+      session_id: process.env["COMPUTE_SESSION_ID"] ?? "",
+      process_id: String(process.pid),
+      job_id: this.jobId,
+    };
+    const entry = {
+      type: "service.1",
+      level,
+      time: new Date().toISOString(),
+      origin: getCallerOrigin(),
+      safe: true,
+      thread: isMainThread ? "main" : `worker-${threadId}`,
+      params: filterUndefinedValues({ ...baseParams, ...params }),
+      message,
+    };
+    process.stdout.write(JSON.stringify(entry) + "\n");
+  }
+}
+
+/**
+ * Extracts the caller's `filename:line` from the stack trace, matching the
+ * Python SDK's `f"{record.filename}:{record.lineno}"` behaviour.
+ *
+ * Uses V8's `Error.prepareStackTrace` to obtain structured CallSite objects
+ * directly, avoiding full stack serialization and regex parsing.
+ *
+ * Frame indices (from `write`):
+ *   0: getCallerOrigin
+ *   1: SlsLogger.write
+ *   2: SlsLogger.(debug|log|info|warn|error)
+ *   3: <actual caller>
+ */
+function getCallerOrigin(): string {
+  const original = Error.prepareStackTrace;
+  try {
+    Error.prepareStackTrace = (_err, stack) => stack;
+    const { stack } = new Error();
+
+    const callSites = stack as unknown as NodeJS.CallSite[];
+    const caller = callSites?.[3];
+    if (caller == null) return "unknown";
+
+    const filePath = caller.getFileName();
+    const lineNumber = caller.getLineNumber();
+    if (filePath == null || lineNumber == null) return "unknown";
+
+    const fileName = filePath.split("/").pop() ?? filePath;
+    return `${fileName}:${lineNumber}`;
+  } finally {
+    Error.prepareStackTrace = original;
+  }
+}
+
+function filterUndefinedValues(
+  params: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, v]) => v !== undefined)
+  );
+}

--- a/typescript-compute-module/src/logging/tests/SlsLogger.test.ts
+++ b/typescript-compute-module/src/logging/tests/SlsLogger.test.ts
@@ -1,0 +1,118 @@
+import { SlsLogger } from "../SlsLogger";
+
+describe("SlsLogger", () => {
+  let writtenLines: string[];
+  const originalWrite = process.stdout.write;
+  const originalEnv = process.env;
+
+  function parseEntry(index = 0): Record<string, any> {
+    return JSON.parse(writtenLines[index]);
+  }
+
+  beforeEach(() => {
+    writtenLines = [];
+    process.stdout.write = ((chunk: string) => {
+      writtenLines.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+    process.env = { ...originalEnv, COMPUTE_SESSION_ID: "test-session" };
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+    process.env = originalEnv;
+  });
+
+  it("should write SLS-formatted JSON to stdout", () => {
+    const logger = new SlsLogger();
+    logger.info("hello world");
+
+    expect(writtenLines).toHaveLength(1);
+    const entry = parseEntry();
+    expect(entry.type).toBe("service.1");
+    expect(entry.level).toBe("INFO");
+    expect(entry.safe).toBe(true);
+    expect(entry.message).toBe("hello world");
+    expect(entry.time).toBeDefined();
+  });
+
+  it("should set origin to caller filename:line", () => {
+    const logger = new SlsLogger();
+    logger.info("origin test");
+
+    const entry = parseEntry();
+    // origin should be "SlsLogger.test.ts:<line>" since the call originates here
+    expect(entry.origin).toMatch(/^SlsLogger\.test\.ts:\d+$/);
+  });
+
+  it("should set thread to current thread name", () => {
+    const logger = new SlsLogger();
+    logger.info("thread test");
+
+    const entry = parseEntry();
+    // Tests run on the main thread
+    expect(entry.thread).toBe("main");
+  });
+
+  it("should auto-inject session_id, process_id, and job_id into params", () => {
+    const logger = new SlsLogger();
+    logger.info("auto params");
+
+    const entry = parseEntry();
+    expect(entry.params.session_id).toBe("test-session");
+    expect(entry.params.process_id).toBe(String(process.pid));
+    expect(entry.params.job_id).toBe("");
+  });
+
+  it("should default session_id to empty string when env var is unset", () => {
+    delete process.env.COMPUTE_SESSION_ID;
+    const logger = new SlsLogger();
+    logger.info("no session");
+
+    expect(parseEntry().params.session_id).toBe("");
+  });
+
+  it("should update job_id via setJobId", () => {
+    const logger = new SlsLogger();
+    logger.setJobId("job-123");
+    logger.info("with job");
+
+    expect(parseEntry().params.job_id).toBe("job-123");
+  });
+
+  it("should merge user params with auto-injected params", () => {
+    const logger = new SlsLogger();
+    logger.info("with extra", { extra: "value" });
+
+    const entry = parseEntry();
+    expect(entry.params.extra).toBe("value");
+    expect(entry.params.session_id).toBe("test-session");
+    expect(entry.params.process_id).toBe(String(process.pid));
+    expect(entry.params.job_id).toBe("");
+  });
+
+  it("should filter out undefined param values", () => {
+    const logger = new SlsLogger();
+    logger.info("partial params", {
+      myParam: undefined,
+      extra: "value",
+    });
+
+    const entry = parseEntry();
+    expect(entry.params.extra).toBe("value");
+    expect(entry.params.process_id).toBe(String(process.pid));
+    expect("myParam" in entry.params).toBe(false);
+  });
+
+  it("should map log levels correctly", () => {
+    const logger = new SlsLogger();
+    logger.debug("a");
+    logger.log("b");
+    logger.info("c");
+    logger.warn("d");
+    logger.error("e");
+
+    const levels = writtenLines.map((l) => JSON.parse(l).level);
+    expect(levels).toEqual(["DEBUG", "INFO", "INFO", "WARN", "ERROR"]);
+  });
+});


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
SLS logging only available if user manually implements the SLS logging formatter
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
SLS logging is part of typescript sdk and we documented how to use it

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

