### PR TITLE
making the job Id and context concurrency safe

### DIFF
--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { HttpStatusCode, isAxiosError } from "axios";
 import { Logger } from "./logger";
 import { Static, TObject } from "@sinclair/typebox";
@@ -41,6 +42,8 @@ export interface QueryContext {
   jobId: string;
 }
 
+export const queryContextStorage = new AsyncLocalStorage<QueryContext>();
+
 export type ResponseQueryListener<M extends QueryResponseMapping> = <
   T extends keyof M
 >(
@@ -77,39 +80,12 @@ export class QueryRunner<M extends QueryResponseMapping> {
         if (jobRequest.status === HttpStatusCode.Ok) {
           const { query, queryType, jobId } =
             jobRequest.data.computeModuleJobV1;
+          const context: QueryContext = { jobId };
           this.logger?.info(`Job received - Query: ${queryType}`, { job_id: jobId });
-          const listener = this.listeners[queryType];
 
-          if (listener?.type === "response") {
-            listener
-              .listener(query, { jobId })
-              .then((response) => computeModuleApi.postResult(jobId, response))
-              .catch((error) => {
-                const sanitizedError = isAxiosError(error) ? sanitizeAxiosError(error) : error;
-                this.logger?.error(`Error executing job: ${sanitizedError}`, { job_id: jobId });
-                computeModuleApi.postResult(jobId, QueryRunner.getFailedQueryResult(sanitizedError));
-              });
-          } else if (listener?.type === "streaming") {
-            const writable = new PassThrough();
-            listener.listener(query, writable, { jobId });
-            computeModuleApi.postStreamingResult(jobId, writable);
-          } else if (this.defaultListener != null) {
-            this.defaultListener(query, queryType, { jobId })
-              .then((response) =>
-                computeModuleApi.postResult(
-                  jobId,
-                  // Convert number to string as per response spec
-                  typeof response === "number" ? response.toString() : response
-                )
-              )
-              .catch((error) => {
-                const sanitizedError = isAxiosError(error) ? sanitizeAxiosError(error) : error;
-                this.logger?.error(`Error executing default listener: ${sanitizedError}`, { job_id: jobId });
-                computeModuleApi.postResult(jobId, QueryRunner.getFailedQueryResult(sanitizedError));
-              });
-          } else {
-            this.logger?.error(`No listener for query type: ${queryType}`);
-          }
+          queryContextStorage.run(context, () => {
+            this.dispatchJob(computeModuleApi, queryType, query, context);
+          });
         }
       } catch (e) {
         if (!isAxiosError(e)) {
@@ -145,6 +121,50 @@ export class QueryRunner<M extends QueryResponseMapping> {
     defaultListener: (query: any, queryType: string, context: QueryContext) => Promise<any>
   ) {
     this.defaultListener = defaultListener;
+  }
+
+  private dispatchJob(
+    computeModuleApi: ComputeModuleApi,
+    queryType: string,
+    query: any,
+    context: QueryContext
+  ): void {
+    const { jobId } = context;
+    const listener = this.listeners[queryType];
+
+    if (listener?.type === "response") {
+      listener
+        .listener(query, context)
+        .then((response) => computeModuleApi.postResult(jobId, response))
+        .catch((error) => this.handleJobError(computeModuleApi, jobId, "job", error));
+    } else if (listener?.type === "streaming") {
+      const writable = new PassThrough();
+      listener.listener(query, writable, context);
+      computeModuleApi.postStreamingResult(jobId, writable);
+    } else if (this.defaultListener != null) {
+      this.defaultListener(query, queryType, context)
+        .then((response) =>
+          computeModuleApi.postResult(
+            jobId,
+            // Convert number to string as per response spec
+            typeof response === "number" ? response.toString() : response
+          )
+        )
+        .catch((error) => this.handleJobError(computeModuleApi, jobId, "default listener", error));
+    } else {
+      this.logger?.error(`No listener for query type: ${queryType}`);
+    }
+  }
+
+  private handleJobError(
+    computeModuleApi: ComputeModuleApi,
+    jobId: string,
+    label: string,
+    error: unknown
+  ): void {
+    const sanitizedError = isAxiosError(error) ? sanitizeAxiosError(error) : error;
+    this.logger?.error(`Error executing ${label}: ${sanitizedError}`, { job_id: jobId });
+    computeModuleApi.postResult(jobId, QueryRunner.getFailedQueryResult(sanitizedError));
   }
 
   private static getFailedQueryResult(error: any): Record<string, string> {

--- a/typescript-compute-module/src/index.ts
+++ b/typescript-compute-module/src/index.ts
@@ -3,4 +3,5 @@ export type { ComputeModuleOptions } from "./ComputeModule";
 export type { Logger, LogParams } from "./logger";
 export { SlsLogger } from "./logging/SlsLogger";
 export type { QueryContext } from "./QueryRunner";
+export { queryContextStorage } from "./QueryRunner";
 export { FoundryService } from "./services/getFoundryServices";

--- a/typescript-compute-module/src/logging/SlsLogger.ts
+++ b/typescript-compute-module/src/logging/SlsLogger.ts
@@ -1,5 +1,6 @@
-import { isMainThread, threadId } from "worker_threads";
+import { isMainThread, threadId } from "node:worker_threads";
 import type { Logger, LogParams } from "../logger";
+import { queryContextStorage } from "../QueryRunner";
 
 type SlsLogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 
@@ -21,15 +22,6 @@ type SlsLogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
  * ```
  */
 export class SlsLogger implements Logger {
-  private jobId: string = "";
-
-  /**
-   * Updates the job ID injected into every subsequent log entry's params.
-   */
-  setJobId(jobId: string): void {
-    this.jobId = jobId;
-  }
-
   debug(message: string, params?: LogParams): void {
     this.write("DEBUG", message, params);
   }
@@ -55,10 +47,11 @@ export class SlsLogger implements Logger {
     message: string,
     params?: LogParams
   ): void {
+    const context = queryContextStorage.getStore();
     const baseParams: Record<string, string> = {
       session_id: process.env["COMPUTE_SESSION_ID"] ?? "",
       process_id: String(process.pid),
-      job_id: this.jobId,
+      job_id: context?.jobId ?? "",
     };
     const entry = {
       type: "service.1",

--- a/typescript-compute-module/src/logging/tests/SlsLogger.test.ts
+++ b/typescript-compute-module/src/logging/tests/SlsLogger.test.ts
@@ -1,4 +1,5 @@
 import { SlsLogger } from "../SlsLogger";
+import { queryContextStorage } from "../../QueryRunner";
 
 describe("SlsLogger", () => {
   let writtenLines: string[];
@@ -72,10 +73,11 @@ describe("SlsLogger", () => {
     expect(parseEntry().params.session_id).toBe("");
   });
 
-  it("should update job_id via setJobId", () => {
+  it("should read job_id from AsyncLocalStorage context", () => {
     const logger = new SlsLogger();
-    logger.setJobId("job-123");
-    logger.info("with job");
+    queryContextStorage.run({ jobId: "job-123" }, () => {
+      logger.info("with job");
+    });
 
     expect(parseEntry().params.job_id).toBe("job-123");
   });


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The logger shares a global variable for jobId that can be overwritten if we have several requests run in parallel.  
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
We create an AsyncLocalStorage that stores instances of QueryContext for each submitted query. The logger logs the jobId from that QueryContext automatically if the SLSLogger is used.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

