### PR TITLE
handle streaming result failures without rethrowing

### DIFF
--- a/typescript-compute-module/package.json
+++ b/typescript-compute-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@palantir/compute-module",
-  "version": "0.2.14",
+  "version": "0.2.15-rc1",
   "description": "Typescript binding for implementing the compute module API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/typescript-compute-module/src/QueryRunner.ts
+++ b/typescript-compute-module/src/QueryRunner.ts
@@ -139,8 +139,20 @@ export class QueryRunner<M extends QueryResponseMapping> {
         .catch((error) => this.handleJobError(computeModuleApi, jobId, "job", error));
     } else if (listener?.type === "streaming") {
       const writable = new PassThrough();
-      listener.listener(query, writable, context);
-      computeModuleApi.postStreamingResult(jobId, writable);
+      try {
+        listener.listener(query, writable, context);
+      } catch (error) {
+        writable.destroy();
+        this.handleJobError(computeModuleApi, jobId, "streaming listener", error);
+        return;
+      }
+      try {
+        computeModuleApi.postStreamingResult(jobId, writable).catch((error) => {
+          this.handleStreamingResultError(jobId, writable, error);
+        });
+      } catch (error) {
+        this.handleStreamingResultError(jobId, writable, error);
+      }
     } else if (this.defaultListener != null) {
       this.defaultListener(query, queryType, context)
         .then((response) =>
@@ -154,6 +166,19 @@ export class QueryRunner<M extends QueryResponseMapping> {
     } else {
       this.logger?.error(`No listener for query type: ${queryType}`);
     }
+  }
+
+  private handleStreamingResultError(
+    jobId: string,
+    writable: PassThrough,
+    error: unknown
+  ): void {
+    const sanitizedError = isAxiosError(error) ? sanitizeAxiosError(error) : error;
+    const formattedError = isAxiosError(sanitizedError)
+      ? formatAxiosErrorResponse(sanitizedError)
+      : sanitizedError;
+    this.logger?.error(`Error streaming job result: ${formattedError}`, { job_id: jobId });
+    writable.destroy();
   }
 
   private handleJobError(

--- a/typescript-compute-module/src/api/ComputeModuleApi.ts
+++ b/typescript-compute-module/src/api/ComputeModuleApi.ts
@@ -67,7 +67,7 @@ export class ComputeModuleApi {
       }
     );
 
-  public postStreamingResult = (jobId: string, response: Writable) => {
+  public postStreamingResult = (jobId: string, response: Writable) =>
     this.axiosInstance.post(
       this.connectionInformation.postResultUri + "/" + jobId,
       response,
@@ -77,7 +77,6 @@ export class ComputeModuleApi {
         },
       }
     );
-  }
  
 
   public postSchema = (schemas: Schema[]) =>

--- a/typescript-compute-module/src/tests/QueryRunner.test.ts
+++ b/typescript-compute-module/src/tests/QueryRunner.test.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { HttpStatusCode } from "axios";
+import { AxiosError, HttpStatusCode } from "axios";
 import { QueryRunner, QueryResponseMapping, QueryContext } from "../QueryRunner";
 import { ComputeModuleApi } from "../api/ComputeModuleApi";
 
@@ -19,7 +19,7 @@ describe("QueryRunner", () => {
     mockComputeModuleApi = {
       getJobRequest: jest.fn(),
       postResult: jest.fn().mockResolvedValue(undefined),
-      postStreamingResult: jest.fn(),
+      postStreamingResult: jest.fn().mockResolvedValue(undefined),
       postSchema: jest.fn(),
     } as unknown as jest.Mocked<ComputeModuleApi>;
   });
@@ -286,6 +286,101 @@ describe("QueryRunner", () => {
       expect(mockComputeModuleApi.postStreamingResult).toHaveBeenCalledWith(
         jobId,
         expect.anything()
+      );
+    });
+
+    it("should handle streaming result post failures without rethrowing", async () => {
+      const jobId = "streaming-post-error-job";
+      const logger = {
+        log: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+      };
+      const axiosError = new AxiosError(
+        "Request failed with status code 500",
+        "ERR_BAD_RESPONSE"
+      );
+
+      mockComputeModuleApi.postStreamingResult.mockRejectedValueOnce(axiosError);
+      mockComputeModuleApi.getJobRequest
+        .mockResolvedValueOnce({
+          status: HttpStatusCode.Ok,
+          data: {
+            type: "computeModuleJobV1",
+            computeModuleJobV1: {
+              jobId,
+              queryType: "testQuery",
+              query: { name: "StreamCompat" },
+            },
+          },
+        } as any)
+        .mockImplementation(() => new Promise(() => {}));
+
+      const queryRunner = new QueryRunner<typeof TEST_QUERY_MAPPING>(
+        {
+          testQuery: {
+            type: "streaming",
+            listener: (_message, responseStream) => {
+              responseStream.write("partial response");
+            },
+          },
+        },
+        undefined,
+        logger
+      );
+
+      queryRunner.run(mockComputeModuleApi);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const postedStream = mockComputeModuleApi.postStreamingResult.mock
+        .calls[0][1] as any;
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Error streaming job result"),
+        { job_id: jobId }
+      );
+      expect(postedStream.destroyed).toBe(true);
+      expect(mockComputeModuleApi.postResult).not.toHaveBeenCalled();
+    });
+
+    it("should report synchronous streaming listener errors as failed results", async () => {
+      const jobId = "streaming-listener-error-job";
+
+      mockComputeModuleApi.getJobRequest
+        .mockResolvedValueOnce({
+          status: HttpStatusCode.Ok,
+          data: {
+            type: "computeModuleJobV1",
+            computeModuleJobV1: {
+              jobId,
+              queryType: "testQuery",
+              query: { name: "StreamCompat" },
+            },
+          },
+        } as any)
+        .mockImplementation(() => new Promise(() => {}));
+
+      const queryRunner = new QueryRunner<typeof TEST_QUERY_MAPPING>({
+        testQuery: {
+          type: "streaming",
+          listener: () => {
+            throw new Error("Streaming listener failed");
+          },
+        },
+      });
+
+      queryRunner.run(mockComputeModuleApi);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockComputeModuleApi.postStreamingResult).not.toHaveBeenCalled();
+      expect(mockComputeModuleApi.postResult).toHaveBeenCalledWith(
+        jobId,
+        expect.objectContaining({
+          error: "Error",
+          reason: "Streaming listener failed",
+        })
       );
     });
   });


### PR DESCRIPTION
## Before this PR
Streaming result exceptions bubbled up to the user code, which if handled incorrectly could lead to the process crashing

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Handle streaming result failures without rethrowing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

